### PR TITLE
chore: added a method to determine whether the consumer should be executed

### DIFF
--- a/sqs_listener/__init__.py
+++ b/sqs_listener/__init__.py
@@ -142,9 +142,15 @@ class SqsListener(object):
             self._queue_url = qs['QueueUrl']
         return sqs
 
+    def _condition_to_listening(self):
+        """
+            Return condition to run listening process.
+        """
+        return True
+    
     def _start_listening(self):
         # TODO consider incorporating output processing from here: https://github.com/debrouwere/sqs-antenna/blob/master/antenna/__init__.py
-        while True:
+        while self._condition_to_listening():
             # calling with WaitTimeSecconds of zero show the same behavior as
             # not specifiying a wait time, ie: short polling
             messages = self._client.receive_message(


### PR DESCRIPTION
Example to override this method to start SO signals 

```
class SignalHandler:
    def __init__(self):
        self.received_signal = False
        signal(SIGINT, self._signal_handler)
        signal(SIGTERM, self._signal_handler)

    def _signal_handler(self, signal, frame):
        logger.info("Handling signal %s, exiting gracefully", signal)
        self.received_signal = True
        
        
 class MyListener(SqsListener):
     def _condition_to_listening(self):
         if not getattr(self, "signal_handler"):
             self.signal_handler = SignalHandler()
         return not signal_handler.received_signal
         
     def handle_message(self, body, attributes, messages_attributes):
         pass
``` 